### PR TITLE
[Workers Editor] Update README and package lock for Cloudflare Workers project deployment button

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Astro Starter Kit: Blog
+HI I AM EDITING THIS FOR THE CREATE PR BUTTON 
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/cloudflare/templates/tree/main/astro-blog-starter-template)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "astro-blog-starter-template",
+  "name": "astro-blog-starter-template-100000000000",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "astro-blog-starter-template",
+      "name": "astro-blog-starter-template-100000000000",
       "dependencies": {
         "@astrojs/cloudflare": "12.6.0",
         "@astrojs/mdx": "4.3.0",


### PR DESCRIPTION
### PR Description

Update README and package-lock.json files

#### Changes
* Modified README.md to test create PR button functionality
* Updated package-lock.json with new package name astro-blog-starter-template-100000000000
		
---

This PR was generated by the Cloudflare Workers Editor.

[Continue Editing](https://dash.cloudflare.com/ca913382d1ac39b396106331875a1313/workers/editor?type=pr&accountTag=ca913382d1ac39b396106331875a1313&repoUrl=https%3A%2F%2Fgithub.com%2Fyomna-shousha%2Fastro-blog-starter-template-100000000000&repoId=1070768115&workerName=astro-blog-starter-template-100000000000&resumeBranch=create-pr-button-text&providerAccountId=219857385)